### PR TITLE
Update vendor_hp_procurve.php

### DIFF
--- a/src/OSS_SNMP/Platforms/vendor_hp_procurve.php
+++ b/src/OSS_SNMP/Platforms/vendor_hp_procurve.php
@@ -40,7 +40,7 @@
 
 if( substr( $sysDescr, 0, 9 ) == 'ProCurve ' )
 {
-    if( preg_match( '/ProCurve (\w+) Switch ([0-9]+), revision ([A-Z0-9\.]+), ROM [A-Z0-9\.]+ .*/',
+    if( preg_match( '/ProCurve (\w+) Switch (\w+).*, revision ([A-Z0-9\.]+), ROM ([A-Z0-9\.]+ .*)/',
             $sysDescr, $matches ) )
     {
         $this->setVendor( 'Hewlett-Packard' );


### PR DESCRIPTION
Adjusted regex string to be able to work with different model strings, which the original was failing to catch.

ie ProCurve J4905A Switch 3400cl-24G, revision M.08.86, ROM I.08.07 (/sw/code/build/makf(ts_08_5))