### PR TITLE
Updated integer parsing for edge cases

### DIFF
--- a/src/OSS_SNMP/SNMP.php
+++ b/src/OSS_SNMP/SNMP.php
@@ -442,10 +442,14 @@ class SNMP
                 break;
 
             case 'INTEGER':
-                if( !is_numeric( $value ) )
-                    $rtn = (int)substr( substr( $value, strpos( $value, '(' ) + 1 ), 0, -1 );
-                else
+                if( !is_numeric( $value ) ){
+                    // find the first digit and offset the string to that point
+                    // just in case there is some mib strangeness going on
+                    preg_match('/\d/', $value, $m, PREG_OFFSET_CAPTURE);
+                    $rtn = (int)substr( $value, $m[0][1] );
+                }else{
                     $rtn = (int)$value;
+                }
                 break;
 
             case 'Counter32':


### PR DESCRIPTION
Changed the default non-numeric response to offset the string to the first digit instead of just removing the first character