### PR TITLE
Fix handling of \r\n delimiter in SNMP response for F10

### DIFF
--- a/src/OSS_SNMP/Platforms/vendor_dell_force10.php
+++ b/src/OSS_SNMP/Platforms/vendor_dell_force10.php
@@ -39,9 +39,10 @@
 // 'Dell Force10 OS Operating System Version: 1.0 Application Software Version: 8.3.12.1 Series: S4810 Copyright (c) 1999-2012 by Dell Inc. All Rights Reserved. Build Time: Sun Nov 18 11:05:15 2012'
 // 'Dell Force10 OS Operating System Version: 2.0 Application Software Version: 9.3(0.0) Series: S4810 Copyright (c) 1999-2014 by Dell Inc. All Rights Reserved. Build Time: Thu Jan 2 02:14:08 2014'
 
-if( substr( $sysDescr, 0, 12 ) == 'Dell Force10 ' )
+if( substr( $sysDescr, 0, 12 ) == 'Dell Force10' )
 {
-    if( preg_match( '/^Dell Force10 OS Operating System Version: ([\d\.]+) Application Software Version:\s([0-9\(\)\.]+)\sSeries:\s([A-Z0-9]+)\sCopyright \(c\) \d+-\d+ by Dell Inc. All Rights Reserved. Build Time:\s[A-Za-z0-9]+\s(([a-zA-Z]+)\s(\d+)\s((\d\d):(\d\d):(\d\d))\s(\d+))$/',
+    $sysDescr = preg_replace('/\R/',' ', $sysDescr );
+    if( preg_match( '/^Dell Force10 OS Operating System Version: ([\d\.]+) Application Software Version:\s([0-9\(\)\.]+)\sSeries:\s([A-Z0-9]+)\sCopyright \(c\) \d+-\d+ by Dell Inc. All Rights Reserved. Build Time:\s[A-Za-z0-9]+\s(([a-zA-Z]+)\s+(\d+)\s((\d\d):(\d\d):(\d\d))\s(\d+))$/',
             $sysDescr, $matches ) )
     {
         $this->setVendor( 'Dell Force10' );


### PR DESCRIPTION
The $sysDesc variable contains \r\n as delimiter which prevents matching.
This commit replaces all types of newlines with spaces. Also fix length
of substr() and allow for more spaces between month and day in the
'Build Time:' field.