### PR TITLE
Add support for current Dell Networking OS

### DIFF
--- a/src/OSS_SNMP/Platforms/vendor_dell_force10.php
+++ b/src/OSS_SNMP/Platforms/vendor_dell_force10.php
@@ -38,18 +38,19 @@
 //
 // 'Dell Force10 OS Operating System Version: 1.0 Application Software Version: 8.3.12.1 Series: S4810 Copyright (c) 1999-2012 by Dell Inc. All Rights Reserved. Build Time: Sun Nov 18 11:05:15 2012'
 // 'Dell Force10 OS Operating System Version: 2.0 Application Software Version: 9.3(0.0) Series: S4810 Copyright (c) 1999-2014 by Dell Inc. All Rights Reserved. Build Time: Thu Jan 2 02:14:08 2014'
+// 'Dell Networking OS Operating System Version: 2.0 Application Software Version: 9.10(0.1P3) Series: S4810 Copyright (c) 1999-2016 by Dell Inc. All Rights Reserved. Build Time: Tue Jun 14 15:00:23 2016'
 
-if( substr( $sysDescr, 0, 12 ) == 'Dell Force10' )
+if( substr( $sysDescr, 0, 5 ) == 'Dell ' )
 {
     $sysDescr = preg_replace('/\R/',' ', $sysDescr );
-    if( preg_match( '/^Dell Force10 OS Operating System Version: ([\d\.]+) Application Software Version:\s([0-9\(\)\.]+)\sSeries:\s([A-Z0-9]+)\sCopyright \(c\) \d+-\d+ by Dell Inc. All Rights Reserved. Build Time:\s[A-Za-z0-9]+\s(([a-zA-Z]+)\s+(\d+)\s((\d\d):(\d\d):(\d\d))\s(\d+))$/',
-            $sysDescr, $matches ) )
+    if( preg_match( '/^Dell (Force10|Networking) OS Operating System Version: ([\d\.]+) Application Software Version:\s([A-Z0-9\(\)\.]+)\sSeries:\s([A-Z0-9]+)\sCopyright \(c\) \d+-\d+ by Dell Inc. All Rights Reserved. Build Time:\s[A-Za-z0-9]+\s(([a-zA-Z]+)\s+(\d+)\s((\d\d):(\d\d):(\d\d))\s(\d+))$/',
+           $sysDescr, $matches ) )
     {
-        $this->setVendor( 'Dell Force10' );
-        $this->setModel( $matches[3] );
-        $this->setOs( "FTOS {$matches[1]}" );
-        $this->setOsVersion( $matches[2] );
-        $this->setOsDate( new \DateTime( "{$matches[6]}/{$matches[5]}/{$matches[11]}:{$matches[7]} +0000" ) );
+        $this->setVendor( "Dell {$matches[1]}" );
+        $this->setModel( $matches[4] );
+        $this->setOs( "FTOS {$matches[2]}" );
+        $this->setOsVersion( $matches[3] );
+        $this->setOsDate( new \DateTime( "{$matches[7]}/{$matches[6]}/{$matches[12]}:{$matches[8]} +0000" ) );
         $this->getOsDate()->setTimezone( new \DateTimeZone( 'UTC' ) );
     }
 


### PR DESCRIPTION
Newer FTOS changed its sysDescr to begin with 'Dell Networking OS' and
also include characters in the 'Application Software Version:'. This
commit enables vendor_dell_force10.php to recognize these FTOS versions
and sets the Vendor accordingly.