### PR TITLE
Fix detection of Cisco Nexus 3500 platform

### DIFF
--- a/src/OSS_SNMP/Platforms/vendor_cisco.php
+++ b/src/OSS_SNMP/Platforms/vendor_cisco.php
@@ -101,7 +101,7 @@ else if( substr( $sysDescr, 0, 11 ) == 'Cisco NX-OS' ) {
     // Cisco NX-OS(tm) nxos.7.0.3.I2.3.bin, Software (nxos), Version 7.0(3)I2(3), RELEASE SOFTWARE Copyright (c) 2002-2013 by Cisco Systems, Inc. Compiled 3/19/2016 22:00:00
     // Cisco NX-OS(tm) n3500, Software (n3500-uk9), Version 6.0(2)A6(3), RELEASE SOFTWARE Copyright (c) 2002-2012 by Cisco Systems, Inc. Compiled 7/1/2015 10:00:00
 
-    if( preg_match( '/^Cisco NX\-OS\(tm\) ([a-zA-Z0-9\.]+), Software \([a-zA-Z0-9\-]+\), Version ([a-zA-Z0-9\.\(\)]+), RELEASE SOFTWARE Copyright \(c\) (?:\d+)-(?:\d+) by Cisco Systems, Inc\.(?: Device Manager Version nms\.sro not found,)? Compiled (\d+)\/(\d+)\/(\d+) (\d+):(\d+):(\d+)$/',
+    if( preg_match( '/^Cisco NX\-OS\(tm\) ([a-zA-Z0-9\.]+), Software \([a-zA-Z0-9\-]+\), Version ([a-zA-Z0-9\.\(\)]+), RELEASE SOFTWARE Copyright \(c\) (?:\d+)-(?:\d+) by Cisco Systems, Inc\.(?: Device Manager Version nms\.sro not found,)?\s*Compiled (\d+)\/(\d+)\/(\d+) (\d+):(\d+):(\d+)$/',
         $sysDescr, $matches ) )
     {
         $this->setVendor( 'Cisco Systems' );

--- a/tests/Tests/OSS_SNMP/Platforms/CiscoTest.php
+++ b/tests/Tests/OSS_SNMP/Platforms/CiscoTest.php
@@ -94,7 +94,7 @@ class CiscoTest extends Platform
         $this->assertEquals( $dt, $p->getOsDate() );
     }
 
-    const CISCO_F = 'Cisco NX-OS(tm) n3500, Software (n3500-uk9), Version 6.0(2)A6(3), RELEASE SOFTWARE Copyright (c) 2002-2012 by Cisco Systems, Inc. Compiled 7/1/2015 10:00:00';
+    const CISCO_F = 'Cisco NX-OS(tm) n3500, Software (n3500-uk9), Version 6.0(2)A6(3), RELEASE SOFTWARE Copyright (c) 2002-2012 by Cisco Systems, Inc.   Compiled 7/1/2015 10:00:00';
 
     public function testCiscoF() {
 


### PR DESCRIPTION
 The sysDescr string of the specific version of this switch and software that I'm
 testing with contains 3 spaces before "Compiled" so the regexp wasn't matching.
 Adding \s* before "Compiled" in the regexp to match a variable number of spaces
 makes this match. This should be slightly more resilient to whatever format
 changes Cisco might make in the future.