### PR TITLE
Support IOS-NX Denali

### DIFF
--- a/src/OSS_SNMP/Platforms/vendor_cisco.php
+++ b/src/OSS_SNMP/Platforms/vendor_cisco.php
@@ -51,7 +51,7 @@ else if( substr( $sysDescr, 0, 18 ) == 'Cisco IOS Software' )
 {
     // 'Cisco IOS Software, s72033_rp Software (s72033_rp-ADVENTERPRISE_WAN-VM), Version 12.2(33)SXI5, RELEASE SOFTWARE (fc2)'
 
-    preg_match( '/Cisco IOS Software, (.+) Software \((.+)\), Version\s([0-9A-Za-z\(\)\.]+), RELEASE SOFTWARE\s\((.+)\)/',
+    preg_match( '/Cisco IOS Software(?: \[Denali\])?, (.+) Software \((.+)\), Version\s([0-9A-Za-z\(\)\.]+), RELEASE SOFTWARE\s\((.+)\)/',
             $sysDescr, $matches );
 
     $this->setVendor( 'Cisco Systems' );


### PR DESCRIPTION
Without this change the code will fail because the regex will only partially match.

Example version string:
`Cisco IOS Software [Denali], Catalyst L3 Switch Software (CAT3K_CAA-UNIVERSALK9-M), Version 16.3.3, RELEASE SOFTWARE (fc3)`