### PR TITLE
Add support for Huawei CloudEngine CE8861EI and ATN C910-D

### DIFF
--- a/src/OSS_SNMP/MIBS/Huawei/System.php
+++ b/src/OSS_SNMP/MIBS/Huawei/System.php
@@ -26,6 +26,9 @@ class System extends \OSS_SNMP\MIB
     const OID_SYSTEM_ADMIN_STATE_MODE           = '.1.3.6.1.4.1.2011.6.3.1.21.0'; // no fn() implemented
     const OID_SYSTEM_ADMIN_STATUS               = '.1.3.6.1.4.1.2011.6.3.1.22.0'; // no fn() implemented
     const OID_SYSTEM_VERSION_VRCB               = '.1.3.6.1.4.1.2011.6.3.1.999.0'; // no fn() implemented
+    const OID_COMPATIBLE_PRODUCT_NAME           = '1.3.6.1.4.1.2011.6.3.11.4.0';  // no fn() implemented
+    const OID_COMPATIBLE_VERSION                = '1.3.6.1.4.1.2011.6.3.11.2.0';
+    const OID_COMPATIBLE_VRCB                   = '1.3.6.1.4.1.2011.6.3.11.3.0';  // no fn() implemented
 
     /**
      * Returns the operating system software version
@@ -34,7 +37,11 @@ class System extends \OSS_SNMP\MIB
      */
     public function softwareVersion()
     {
+      try {
         return $this->getSNMP()->get( self::OID_SYSTEM_SOFTWARE_VERSION );
+      } catch ( \OSS_SNMP\Exception $e ) {
+        return $this->getSNMP()->get( self::OID_COMPATIBLE_VERSION );
+      }
     }
 
     /**

--- a/src/OSS_SNMP/Platforms/vendor_huawei.php
+++ b/src/OSS_SNMP/Platforms/vendor_huawei.php
@@ -29,6 +29,9 @@ if( substr( strtolower($sysDescr), 0, 6 ) == 'huawei' )
         case '.1.3.6.1.4.1.2011.2.239.66':
             $this->setModel( "CE6881-48S6CQ" );
             break;
+        case '.1.3.6.1.4.1.2011.2.239.50':
+            $this->setModel(" CE8850-64CQ-EI " );
+            break;
         case '.1.3.6.1.4.1.2011.2.220.35':
             $this->setModel( "ATN 910C-D" );
             break;

--- a/src/OSS_SNMP/Platforms/vendor_huawei.php
+++ b/src/OSS_SNMP/Platforms/vendor_huawei.php
@@ -26,6 +26,9 @@ if( substr( strtolower($sysDescr), 0, 6 ) == 'huawei' )
         case '.1.3.6.1.4.1.2011.2.239.51':
             $this->setModel( "CE8861EI" );
             break;
+        case '.1.3.6.1.4.1.2011.2.239.66':
+            $this->setModel( "CE6881-48S6CQ" );
+            break;
         case '.1.3.6.1.4.1.2011.2.220.35':
             $this->setModel( "ATN 910C-D" );
             break;

--- a/src/OSS_SNMP/Platforms/vendor_huawei.php
+++ b/src/OSS_SNMP/Platforms/vendor_huawei.php
@@ -23,6 +23,12 @@ if( substr( strtolower($sysDescr), 0, 6 ) == 'huawei' )
         case '.1.3.6.1.4.1.2011.2.6.6.1':
             $this->setModel( "MA5300V1" );
             break;
+        case '.1.3.6.1.4.1.2011.2.239.51':
+            $this->setModel( "CE8861EI" );
+            break;
+        case '.1.3.6.1.4.1.2011.2.220.35':
+            $this->setModel( "ATN 910C-D" );
+            break;
         default:
             $this->setModel( null );
     }

--- a/src/OSS_SNMP/Platforms/vendor_huawei.php
+++ b/src/OSS_SNMP/Platforms/vendor_huawei.php
@@ -32,6 +32,9 @@ if( substr( strtolower($sysDescr), 0, 6 ) == 'huawei' )
         case '.1.3.6.1.4.1.2011.2.239.50':
             $this->setModel(" CE8850-64CQ-EI " );
             break;
+        case '.1.3.6.1.4.1.2011.2.223.2':
+            $this->setModel( "S7706" );
+            break;
         case '.1.3.6.1.4.1.2011.2.220.35':
             $this->setModel( "ATN 910C-D" );
             break;


### PR DESCRIPTION
These add support for newer Huawei switches that use the HUAWEI-DEVICE-MIB hwCompatible* OIDs.
In our case it's CE8861EI and ATN C910-D.
There's also a fix for the already implemented Huawei S6720 where Huawei introduced newlines in the sysDescr string.