### PR TITLE
JunOS J2320: Fallback to 'UTC' when parsing sysDescr

### DIFF
--- a/src/OSS_SNMP/Platforms/vendor_juniper.php
+++ b/src/OSS_SNMP/Platforms/vendor_juniper.php
@@ -42,7 +42,8 @@ if( substr( $sysDescr, 0, 16 ) == 'Juniper Networks' )
 
         if (preg_match('/Build date: (\d\d\d\d-\d\d-\d\d) (\d\d:\d\d:\d\d) ([A-Za-z]+)/', $sysDescr, $d)) {
             $this->setOsDate(new \DateTime("{$d[1]} {$d[2]} +00:00"));
-            $this->getOsDate()->setTimezone(new \DateTimeZone($d[3]));
+            $tz = in_array($d[3], \DateTimeZone::listIdentifiers()) ? $d[3] : 'UTC';
+            $this->getOsDate()->setTimezone(new \DateTimeZone($tz));
         }
 
     }


### PR DESCRIPTION
We have an old J2320 for lab purposes, but when IXPmanager tries to fetch SNMP data using OSS_SNMP, this leads to an error 500:

    [2022-03-15 19:53:47] production.ERROR: DateTimeZone::__construct(): Unknown or bad timezone (UT) {"userId":1,"exception":"[object] (Exception(code: 0): 
    DateTimeZone::__construct(): Unknown or bad timezone (UT) at /srv/ixpmanager/vendor/opensolutions/oss-snmp/src/OSS_SNMP/Platforms/vendor_juniper.php:46)
    [stacktrace]
    #0 /srv/ixpmanager/vendor/opensolutions/oss-snmp/src/OSS_SNMP/Platforms/vendor_juniper.php(46): DateTimeZone->__construct()
    #1 /srv/ixpmanager/vendor/opensolutions/oss-snmp/src/OSS_SNMP/Platform.php(133): include('...')
    #2 /srv/ixpmanager/vendor/opensolutions/oss-snmp/src/OSS_SNMP/Platform.php(107): OSS_SNMP\\Platform->parse()
    #3 /srv/ixpmanager/vendor/opensolutions/oss-snmp/src/OSS_SNMP/SNMP.php(964): OSS_SNMP\\Platform->__construct()
    #4 /srv/ixpmanager/app/Models/Switcher.php(296): OSS_SNMP\\SNMP->getPlatform()
    ...

Its SNMP sysDescr string is as follows according to SNMP:

    iso.3.6.1.2.1.1.1.0 = STRING: "Juniper Networks, Inc. jsr2320 internet router, kernel JUNOS 12.1X46-D40.2 #0: 2015-09-26 03:30:48 UTC builder@greteth.juniper.net:/volume/build/junos/12.1/service/12.1X46-D40.2/obj-i386/junos/bsd/kernels/JSR/kernel Build date: 2015-09-26 04:16:40 UT"

Somehow the timezone UTC is chopped to UT, not sure due to what reasons (snmp doesn't enforce a max_length i believe?).
I feel the appropriate fix here would be to fall back to timezone UTC, such that relying tooling such as IXPmanager can at least function when the build string is not entirely valid.

Looking forward to any feedback :)